### PR TITLE
Fix collapse more/less issue

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -311,17 +311,19 @@ nav {
 .tab{
     padding-left: 1.5rem;
 }
-#collapse_arrow{
+
+.collapse_arrow {
     font-size: large;
 }
 
-#collapse_arrow.collapsed:before
+.collapse_arrow.collapsed:before
 {
     content:'+ more' ;
     font-style: italic;
     font-size: 18px;
 }
-#collapse_arrow:before
+
+.collapse_arrow:before
 {
     content:'- less' ;
     font-style: italic;

--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
                             </tbody>
                         </table>
 
-                        <p id="collapse_arrow" data-toggle="collapse" data-target="#content_{{project.id_project}}" aria-controls="content_{{project.id_project}}" aria-expanded="false" aria-label="Toggle content"></p>
+                        <p class="collapse_arrow collapsed" data-toggle="collapse" data-target="#content_{{project.id_project}}" aria-controls="content_{{project.id_project}}" aria-expanded="false" aria-label="Toggle content"></p>
 
                         <div class="no-margin collapse" id="content_{{project.id_project}}">
                             <br>
@@ -380,7 +380,7 @@
                             </tbody>
                         </table>
 
-                        <p id="collapse_arrow" data-toggle="collapse" data-target="#content_{{project.id_project}}" aria-controls="content_{{project.id_project}}" aria-expanded="false" aria-label="Toggle content"></p>
+                        <p class="collapse_arrow collapsed" data-toggle="collapse" data-target="#content_{{project.id_project}}" aria-controls="content_{{project.id_project}}" aria-expanded="false" aria-label="Toggle content"></p>
 
                         <div class="no-margin collapse" id="content_{{project.id_project}}">
                             <br>
@@ -429,7 +429,7 @@
                             </tbody>
                         </table>
 
-                        <p id="collapse_arrow" data-toggle="collapse" data-target="#content_{{project.id_project}}" aria-controls="content_{{project.id_project}}" aria-expanded="false" aria-label="Toggle content"></p>
+                        <p class="collapse_arrow collapsed" data-toggle="collapse" data-target="#content_{{project.id_project}}" aria-controls="content_{{project.id_project}}" aria-expanded="false" aria-label="Toggle content"></p>
 
                         <div class="no-margin collapse" id="content_{{project.id_project}}">
                             <br>
@@ -494,7 +494,7 @@
                             </tbody>
                         </table>
 
-                        <p id="collapse_arrow" data-toggle="collapse" data-target="#content_{{project.id_project}}" aria-controls="content_{{project.id_project}}" aria-expanded="false" aria-label="Toggle content"></p>
+                        <p class="collapse_arrow collapsed" data-toggle="collapse" data-target="#content_{{project.id_project}}" aria-controls="content_{{project.id_project}}" aria-expanded="false" aria-label="Toggle content"></p>
 
                         <div class="no-margin collapse" id="content_{{project.id_project}}">
                             <br>
@@ -542,7 +542,7 @@
                             </tbody>
                         </table>
 
-                        <p id="collapse_arrow" data-toggle="collapse" data-target="#content_{{project.id_project}}" aria-controls="content_{{project.id_project}}" aria-expanded="false" aria-label="Toggle content"></p>
+                        <p class="collapse_arrow collapsed" data-toggle="collapse" data-target="#content_{{project.id_project}}" aria-controls="content_{{project.id_project}}" aria-expanded="false" aria-label="Toggle content"></p>
 
                         <div class="no-margin collapse" id="content_{{project.id_project}}">
                             <br>


### PR DESCRIPTION
- Changed duplicated collapse_arrow IDs to classes for styling
- Added "collapsed" style in the HTML to make the initial state consistent with the collapsed state. 

Re: mobile you don't have the collapse functionality used there yet, but the existing approach for desktop can be used there:

```
                        <p class="collapse_arrow collapsed" data-toggle="collapse" data-target="#content_{{project.id_project}}" aria-controls="content_{{project.id_project}}" aria-expanded="false" aria-label="Toggle content"></p>

                        <div class="no-margin collapse" id="content_{{project.id_project}}">
                            <br>
                            {{ project.content }}
                        </div>
```

Just make sure to add an `_mobile` to the end of `id="content_{{project.id_project}}"` and its `data-target` value so the divs in the mobile version have unique IDs. HTML element IDs always need to be unique or things will randomly break.

